### PR TITLE
Minor improvements in support of consuming Azure ticket data in mwstats

### DIFF
--- a/tap_azure_tickets/schemas/projects.json
+++ b/tap_azure_tickets/schemas/projects.json
@@ -10,6 +10,11 @@
         "string"
       ]
     },
+    "org": {
+      "type": [
+        "string"
+      ]
+    },
     "abbreviation": {
       "type": [
         "null",

--- a/tap_azure_tickets/schemas/teams.json
+++ b/tap_azure_tickets/schemas/teams.json
@@ -10,6 +10,11 @@
         "string"
       ]
     },
+    "org": {
+      "type": [
+        "string"
+      ]
+    },
     "description": {
       "type": [
         "null",

--- a/tap_azure_tickets/schemas/updates.json
+++ b/tap_azure_tickets/schemas/updates.json
@@ -108,6 +108,12 @@
         "null",
         "string"
       ]
+    },
+    "workItemSdcId": {
+      "type": [
+        "null",
+        "string"
+      ]
     }
   }
 }

--- a/tap_azure_tickets/schemas/workitems.json
+++ b/tap_azure_tickets/schemas/workitems.json
@@ -26,10 +26,10 @@
       ]
     },
     "assignedTo": {
-      "$ref": "UserObject"
+      "$ref": "#/definitions/UserObject"
     },
     "closedBy": {
-      "$ref": "UserObject"
+      "$ref": "#/definitions/UserObject"
     },
     "closedDate": {
       "type": [
@@ -51,7 +51,7 @@
       ]
     },
     "changedBy": {
-      "$ref": "UserObject"
+      "$ref": "#/definitions/UserObject"
     },
     "changedDate": {
       "type": [
@@ -61,7 +61,7 @@
       "format": "date-time"
     },
     "createdBy": {
-      "$ref": "UserObject"
+      "$ref": "#/definitions/UserObject"
     },
     "createdDate": {
       "type": [
@@ -89,6 +89,12 @@
       ],
       "format": "date-time"
     },
+    "iterationPath": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "priority": {
       "type": [
         "null",
@@ -96,7 +102,7 @@
       ]
     },
     "resolvedBy": {
-      "$ref": "UserObject"
+      "$ref": "#/definitions/UserObject"
     },
     "resolvedDate": {
       "type": [


### PR DESCRIPTION
Add a few new fields and adjust some ID values in order to enable certain joins to be made from `mwstats` downstream processing.

# Testing
Dropped existing Azure tickets schema for my test or and ran ingestion again from `scheduled` repo. Verified that the new fields were created in Snowflake and had expected values.