### PR TITLE
Update filters to allow project id to be used as filter, add projects normalized

### DIFF
--- a/tap_azure_tickets/__init__.py
+++ b/tap_azure_tickets/__init__.py
@@ -960,8 +960,6 @@ def sync_project_normalized(schema, org, project, teams, state, mdata, start_dat
     with metrics.record_counter(streamId) as counter:
         extraction_time = singer.utils.now()
 
-        logger.info(json.dumps(project, indent=2))
-
         emit_records(
             streamId,
             schema,

--- a/tap_azure_tickets/schemas/projects_normalized.json
+++ b/tap_azure_tickets/schemas/projects_normalized.json
@@ -1,0 +1,31 @@
+{
+  "title": "Project Normalized",
+  "type": [
+    "null",
+    "object"
+  ],
+  "properties": {
+    "id": {
+      "type": [
+        "string"
+      ]
+    },
+    "name": {
+      "type": [
+        "string"
+      ]
+    },
+    "description": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "url": {
+      "type": [
+        "null",
+        "string"
+      ]
+    }
+  }
+}


### PR DESCRIPTION

## How was this tested
- [x] Tested with racingDigital, schooltool, and qualisflow
    - Verified projects were discovered and the correct fields were emitted
- [x] Tested project filtering with project name
- [x] Tested project filtering with project id